### PR TITLE
add_facting_about_firefox

### DIFF
--- a/data/facts.json
+++ b/data/facts.json
@@ -15,6 +15,7 @@
     "There is a glacier called Blood Falls in Antarctica that regularly pours out red liquid, making it look like the ice is bleeding. (It's actually oxidised salty water).",
     "Sean Connery wore a toupee in all his James Bond movies.",
     "All swans in England belong to the queen.",
+    " Firefox logo is Derived form the Red panda so actually it is not a Fox it is a Redpanda "
     "Hacktoberfest is a month long celebration of open source software. You can win Tshirts by contributing in between 1st Oct to 31st Oct to open source."
   ]
 }


### PR DESCRIPTION
#414 
Adding a fact about firefox that define how the logo is Designed and where it derived 

#### Short description of what this resolves:
contributing to Facts #414 
### Changes proposed in this pull request:
adding a Fact about logo of Firefox that help people to know real thing not myth ;We are open source folks we should real facts not myth 
-
-
-

**Fixes**: #